### PR TITLE
fix main & add grunt-cli dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
   "name": "css.js",
   "version": "1.0.0",
-  "description": "css.js ======",
-  "main": "Gruntfile.js",
+  "description": "A lightweight, battle tested, fast, CSS parser in JavaScript.",
+  "main": "css.js",
   "directories": {
     "test": "tests"
   },
   "dependencies": {},
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-qunit": "^0.5.2",


### PR DESCRIPTION
- The main file is set to the `grunt` config not the `css.js` file.
- Added better description.
- Added `grunt-cli`.
